### PR TITLE
Add a hook to allow subclasses to specify a firefox profile.

### DIFF
--- a/sbo_selenium/testcase.py
+++ b/sbo_selenium/testcase.py
@@ -252,7 +252,7 @@ class SeleniumTestCase(LiveServerTestCase):
         if os.getenv('SELENIUM_HOST'):
             self.sel = self.sauce_labs_driver()
         elif self.browser == 'firefox':
-            firefox_profile = Firefox(self.get_firefox_profile())
+            self.sel = Firefox(self.get_firefox_profile())
         elif self.browser == 'htmlunit':
             self.sel = RemoteWebDriver(desired_capabilities=DesiredCapabilities.HTMLUNITWITHJS)
         elif self.browser in ['ios', 'ipad', 'ipod', 'iphone']:

--- a/sbo_selenium/testcase.py
+++ b/sbo_selenium/testcase.py
@@ -209,6 +209,9 @@ class SeleniumTestCase(LiveServerTestCase):
     of which browser they're going to be run in.
     """
 
+    def get_firefox_profile(self):
+        return None
+
     @classmethod
     def appium_command_executor(cls):
         """ Get the command executor URL for iOS simulator testing """
@@ -249,7 +252,11 @@ class SeleniumTestCase(LiveServerTestCase):
         if os.getenv('SELENIUM_HOST'):
             self.sel = self.sauce_labs_driver()
         elif self.browser == 'firefox':
-            self.sel = Firefox()
+            firefox_profile = self.get_firefox_profile()
+            if firefox_profile:
+                self.sel = Firefox(firefox_profile)
+            else:
+                self.sel = Firefox()
         elif self.browser == 'htmlunit':
             self.sel = RemoteWebDriver(desired_capabilities=DesiredCapabilities.HTMLUNITWITHJS)
         elif self.browser in ['ios', 'ipad', 'ipod', 'iphone']:

--- a/sbo_selenium/testcase.py
+++ b/sbo_selenium/testcase.py
@@ -252,11 +252,7 @@ class SeleniumTestCase(LiveServerTestCase):
         if os.getenv('SELENIUM_HOST'):
             self.sel = self.sauce_labs_driver()
         elif self.browser == 'firefox':
-            firefox_profile = self.get_firefox_profile()
-            if firefox_profile:
-                self.sel = Firefox(firefox_profile)
-            else:
-                self.sel = Firefox()
+            firefox_profile = Firefox(self.get_firefox_profile())
         elif self.browser == 'htmlunit':
             self.sel = RemoteWebDriver(desired_capabilities=DesiredCapabilities.HTMLUNITWITHJS)
         elif self.browser in ['ios', 'ipad', 'ipod', 'iphone']:


### PR DESCRIPTION
On a couple occasions I've wanted to pass a different profile when starting the Firefox browser. I believe this hook can help with that.

If you think it's a good idea, let me know and I'll make sure to include the docs and whatever else is needed in the request.