### PR TITLE
Legacy optparse compat was removed in 1.10

### DIFF
--- a/sbo_selenium/management/commands/selenium.py
+++ b/sbo_selenium/management/commands/selenium.py
@@ -47,6 +47,9 @@ class Command(BaseCommand):
         for option in OPTIONS:
             parser.add_argument(*option[0], **option[1])
 
+        if django.VERSION > (1, 9):
+            parser.add_argument('args', nargs='*')
+
     def create_parser(self, prog_name, subcommand):
         """
         Override the base create_parser() method to add this command's custom


### PR DESCRIPTION
This module is really really great, I love it !

However, we run tests against django-master in django-session-security and django-autocomplete-light, to make it easier to support it when it's officialy released.

I couldn't get sbo-selenium's own tests to run locally, it's stuck at "A page without accessibility problems should pass the audit ...", so I can't push this PR further. But it works for me on Django 1.9 already, and this patch is needed for 1.10.

Keep up the great work !