### PR TITLE
FR-1285 | Fix arguments on Django 1.8+, update test dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ run.  On a local machine, you'll need to set the ``SELENIUM_SAUCE_*`` Django
 settings described above and use a couple of command-line parameters in
 addition to the ``-b`` browser name setting mentioned previously:
 
-* ``-p`` or ``--platform`` - The name and version of the operating system to
+* ``--platform`` - The name and version of the operating system to
   use.
 * ``--browser-version`` - The version number of the browser to use.
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 sbo-selenium Changelog
 ======================
 
+0.6.0 (2016-03-29)
+------------------
+* Removed the ``-p`` alias for ``--platform``, as it now conflicts with
+  the ``--plugins`` parameter in the base Django test command
+* Fixed support for the underlying test command's standard options under
+  Django 1.8 and above
+* Confirmed compatibility with Django 1.9 and current master
+* Fixed a minor incompatibility in ``audit_accessibility()`` with
+  accessibility developer tools 2.10.1
+
 0.5.1 (2016-03-03)
 ------------------
 * Support accessibility developer tools 2.10.1

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -39,7 +39,7 @@ if virtual_env:
 
     os.system('requirements/clean_up_requirements.py')
     # Set Django version to use outside of tox
-    os.system("pip install Django==1.8.4")
+    os.system("pip install Django==1.9.4")
     os.system("pip install --requirement requirements/base.txt")
     os.system("pip install --requirement requirements/tox.txt")
     os.system("pip install --requirement requirements/tests.txt")

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -3,10 +3,10 @@
 # Indirect dependencies first, exact versions for consistency
 
 # flake8
-mccabe==0.3.1
-pep8==1.6.2
-pyflakes==1.0.0
+mccabe==0.4.0
+pep8==1.7.0
+pyflakes==1.1.0
 
 # And now the direct dependencies
 
-flake8==2.5.0
+flake8==2.5.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,10 +1,10 @@
 # Core dependencies common to all Python interpreters
 
 # Python packaging utilities
-setuptools==18.4
+setuptools==20.4
 
 # Package manager
-pip==7.1.2
+pip==8.1.1
 
 # And now the direct dependencies
 
@@ -12,7 +12,7 @@ pip==7.1.2
 # test multiple versions of it
 
 # HTTP library for calls to Sauce REST API for reporting test results
-requests==2.8.1
+requests==2.9.1
 
 # Python's Selenium driver (for browser automation)
-selenium==2.48.0
+selenium==2.53.1

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -2,21 +2,21 @@
 
 # Indirect dependencies to pin for consistency
 
-# readme -> bleach -> html5lib, sbo-sphinx -> Sphinx
+# readme_renderer -> bleach -> html5lib, sbo-sphinx -> Sphinx
 six==1.10.0
 
-# readme -> bleach
+# readme_renderer -> bleach
 html5lib==0.9999999
 
-# readme
+# readme_renderer
 bleach==1.4.2
 
-# readme, sbo-sphinx -> Sphinx
+# readme_renderer, sbo-sphinx -> Sphinx
 docutils==0.12
-Pygments==2.0.2
+Pygments==2.1.3
 
 # sbo-sphinx -> Sphinx -> Babel
-pytz==2015.7
+pytz==2016.3
 
 # sbo-sphinx -> Sphinx -> Jinja2
 MarkupSafe==0.23
@@ -25,21 +25,21 @@ MarkupSafe==0.23
 PyStemmer==1.3.0
 
 # sbo-sphinx-> Sphinx
-Babel==2.1.1
+Babel==2.2.0
 Jinja2==2.8
-snowballstemmer==1.2.0
+snowballstemmer==1.2.1
 
 # sbo-sphinx
-Sphinx==1.3.1
+Sphinx==1.4
 
 # Sphinx themes (circular dependencies of Sphinx)
-alabaster==0.7.6
+alabaster==0.7.7
 sphinx_rtd_theme==0.1.9
 
 # Direct dependencies
 
 # The README parser used by PyPI, used to validate README.rst
-readme==0.6.0
+readme_renderer==0.7.0
 
 # Utilities for managing technical documentation
 sbo-sphinx==2.2.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,19 +6,19 @@
 path.py==8.1.2
 
 # ipdb -> ipython -> traitlets
-decorator==4.0.4
+decorator==4.0.9
 ipython-genutils==0.1.0
 
 # ipdb -> ipython
 appnope==0.1.0; sys_platform == 'darwin'
 gnureadline==6.3.3; sys_platform == 'darwin'
-pexpect==3.3; sys_platform != 'win32'
-pickleshare==0.5
+pexpect==4.0.1; sys_platform != 'win32'
+pickleshare==0.6
 simplegeneric==0.8.1
-traitlets==4.0.0
+traitlets==4.2.1
 
 # ipdb
-ipython==4.0.0
+ipython==4.1.2
 
 # django-nose
 nose==1.3.7
@@ -26,7 +26,7 @@ nose==1.3.7
 # Direct dependencies for running tests
 
 # Our testing framework
-django-nose==1.4.2
+django-nose==1.4.3
 
 # A better debugger
-ipdb==0.8.1
+ipdb==0.9.0

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -3,8 +3,8 @@
 
 # tox dependencies
 pluggy==0.3.1
-py==1.4.30
-virtualenv==13.1.2
+py==1.4.31
+virtualenv==15.0.1
 
 # For managing test environments
-tox==2.1.1
+tox==2.3.1

--- a/requirements/uninstall.txt
+++ b/requirements/uninstall.txt
@@ -1,2 +1,3 @@
 # Packages which were once dependencies, but should now be removed if present.
 
+readme

--- a/sbo_selenium/management/commands/selenium.py
+++ b/sbo_selenium/management/commands/selenium.py
@@ -22,7 +22,7 @@ else:
 OPTIONS = (
     (('-b', '--browser'), {'dest': 'browser_name', 'default': settings.SELENIUM_DEFAULT_BROWSER, 'help': 'Name of the browser to run the tests in (default is SELENIUM_DEFAULT_BROWSER)'}),
     (('-n',), {'dest': 'count', 'type': int, 'default': 1, 'help': 'Number of times to run each test'}),
-    (('-p', '--platform'), {'dest': 'platform', 'help': 'OS and version thereof for the Sauce OnDemand VM to use'}),
+    (('--platform',), {'dest': 'platform', 'help': 'OS and version thereof for the Sauce OnDemand VM to use'}),
     (('--browser-version',), {'dest': 'browser_version', 'help': 'Browser version for the Sauce OnDemand VM to use'}),
     (('--tunnel-identifier',), {'dest': 'tunnel_id', 'help': 'Sauce Connect tunnel identifier'}),
 )
@@ -44,6 +44,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """Command line arguments for Django 1.8+"""
+        # Add the underlying test command arguments first
+        test_command = TestCommand()
+        test_command.add_arguments(parser)
+
         for option in OPTIONS:
             parser.add_argument(*option[0], **option[1])
 

--- a/sbo_selenium/templates/sbo_selenium/good_accessibility.html
+++ b/sbo_selenium/templates/sbo_selenium/good_accessibility.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Example of good (or rather trivial) accessibility</title>
 </head>

--- a/sbo_selenium/testcase.py
+++ b/sbo_selenium/testcase.py
@@ -333,7 +333,7 @@ class SeleniumTestCase(LiveServerTestCase):
             script += line.strip()
         self.sel.execute_script(script)
         # Wait for the script to finish loading
-        self.wait_for_condition('return axs.AuditRule.specs.videoWithoutCaptions !== "undefined";')
+        self.wait_for_condition('return axs.AuditRules.specs.videoWithoutCaptions !== "undefined";')
         # Now run the audit and inspect the results
         self.sel.execute_script('axs_audit_results = axs.Audit.run();')
         failed = self.sel.execute_script('return axs_audit_results.some(function (element, index, array) { return element.result === "FAIL" });')

--- a/sbo_selenium/tests/test_arguments.py
+++ b/sbo_selenium/tests/test_arguments.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals
+
+import sys
+
+from django.utils.six import StringIO
+
+from django.test import TestCase
+
+from sbo_selenium.management.commands.selenium import Command
+
+
+class TestArguments(TestCase):
+    """
+    Test cases for the command line arguments of the selenium management
+    command.
+    """
+
+    def test_base_arguments(self):
+        """ The "selenium" management command should inherit the base test command's arguments """
+        self._assert_in_help('--liveserver')
+
+    def test_extra_arguments(self):
+        """ The "selenium" management command should have its own custom arguments """
+        self._assert_in_help('--browser-version')
+
+    def _assert_in_help(self, text):
+        """Assert that the selenium command's help output includes the given text"""
+        output = StringIO()
+        real_stdout = sys.stdout
+        try:
+            sys.stdout = output
+            command = Command()
+            command.print_help('manage.py', 'selenium')
+        finally:
+            sys.stdout = real_stdout
+        self.assertIn(text, output.getvalue())

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 import codecs
-import os
-from pip.download import PipSession
-from pip.index import PackageFinder
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 install_requires = [
@@ -12,15 +8,6 @@ install_requires = [
     'requests',
     'selenium',
 ]
-
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    root_dir = os.path.abspath(os.path.dirname(__file__))
-    session = PipSession()
-    requirements_path = os.path.join(root_dir, 'requirements', 'documentation.txt')
-    finder = PackageFinder([], [], session=session)
-    requirements = parse_requirements(requirements_path, finder, session=session)
-    install_requires.extend([str(r.req) for r in requirements])
 
 with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()
 
 
-version = '0.5.1'  # Remember to update docs/CHANGELOG.rst when this changes
+version = '0.6.0'  # Remember to update docs/CHANGELOG.rst when this changes
 
 setup(
     name="sbo-selenium",
@@ -39,6 +39,10 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.6',
+        'Framework :: Django :: 1.7',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -48,6 +52,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development',
         'Topic :: Software Development :: Testing',
     ],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/test_settings.py
+++ b/test_settings.py
@@ -86,6 +86,8 @@ TEMPLATE_DIRS = (
 )
 
 INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
     'django.contrib.staticfiles',
     'sbo_selenium',
     'django_nose',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py{27,34}-django{16,17,18},py35-django18
+envlist = py{27,34}-django{16,17,18,19,master},py35-django{18,19,master}
 
 [testenv]
 deps =
     django16: Django==1.6.11
-    django17: Django==1.7.10
-    django18: Django==1.8.5
+    django17: Django==1.7.11
+    django18: Django==1.8.11
+    django19: Django==1.9.4
+    master: git+git://github.com/django/django.git
     -r{toxinidir}/requirements/tests.txt
 setenv =
     DJANGO_SETTINGS_MODULE=test_settings


### PR DESCRIPTION
* Removed the ``-p`` alias for ``--platform``, as it now conflicts with the ``--plugins`` parameter in the base Django test command
* Fixed support for the underlying test command's standard options under Django 1.8 and above
* Confirmed compatibility with Django 1.9 and current master
* Fixed a minor incompatibility in ``audit_accessibility()`` with accessibility developer tools 2.10.1