### PR TITLE
TRI-1188 | Support for explicit command executor, other fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,8 +160,23 @@ You can use the ``-b`` or ``--browser`` parameter to change this::
 
 Valid browser names are "chrome", "firefox", "htmlunit", "ios", "opera",
 "phantomjs", and "safari" ("ipad", "iphone", and "ipod" are treated as
-synonyms for "ios", the form factor is chosen in Appium).  Alternatively,
-tests can be run at Sauce Labs; see below for details.
+synonyms for "ios", the form factor is chosen in Appium).
+
+If you want to specify a specific Selenium server to use as a command executor
+(whether running on localhost, a specific remote server, a Docker container,
+etc.), you can use the ``--command-executor`` parameter::
+
+    ./manage.py selenium -b firefox --command-executor=http://127.0.0.1:4444/wd/hub
+
+Note that if you are using a command executor in a Docker container, a remote
+host, etc., you should not rely on ``localhost`` or ``127.0.0.1`` in
+``DJANGO_LIVE_TEST_SERVER_ADDRESS``.  Instead, either specify the real IP
+address (rarely ideal) or try to deduce it via code like the following::
+
+    import socket
+    DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(socket.gethostbyname(socket.gethostname()))
+
+Alternatively, tests can be run at Sauce Labs; see below for details.
 
 You can also specify the number of times to run the tests (for example, if you
 have a test that is failing intermittently for some reason and want to run it

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 sbo-selenium Changelog
 ======================
 
+0.7.0 (2016-04-20)
+------------------
+* Added the ``--command-executor`` option for specifying which Selenium server
+  to use, if not localhost
+* Fixed handling of custom parameters to work with recent versions of
+  django-nose
+* Changed monitoring of the Selenium server auto-launching to watch stderr
+  instead of stdout for the startup complete message, as recent versions of
+  Selenium seem to have moved the startup output there
+
 0.6.0 (2016-03-29)
 ------------------
 * Removed the ``-p`` alias for ``--platform``, as it now conflicts with

--- a/sbo_selenium/utils.py
+++ b/sbo_selenium/utils.py
@@ -144,7 +144,7 @@ class InputStreamChunker(threading.Thread):
             marker.pop(0)
             marker.append(l)
             if marker != self._stream_delimiter:
-                tf.write(l)
+                tf.write(unicode(l))
             else:
                 # chopping off the marker first
                 tf.seek(self._stream_roll_back_len, 2)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()
 
 
-version = '0.6.0'  # Remember to update docs/CHANGELOG.rst when this changes
+version = '0.7.0'  # Remember to update docs/CHANGELOG.rst when this changes
 
 setup(
     name="sbo-selenium",

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,9 +1,11 @@
 import os
+import socket
 
 DEBUG = False
 JS_DEBUG = False
 ALLOWED_HOSTS = ['localhost']
-DJANGO_LIVE_TEST_SERVER_ADDRESS = 'localhost:9090'
+IP_ADDRESS = socket.gethostbyname(socket.gethostname())
+DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(IP_ADDRESS)
 SELENIUM_SAUCE_VERSION = '2.41.0'
 SELENIUM_TIMEOUT = 10
 


### PR DESCRIPTION
This should fix things to the point where you can tell it where a Selenium server is running in a Docker container, and it will be used with tests passing.  Next is to automatically start the container at the start of the test run.