### PR TITLE
TRI-1188 | Add support for managing a Selenium Docker container

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,16 @@ runs:
   none are specified.  Should be an array of test
   specifications (see `Running Tests`_ below for examples).  Default value is
   an empty list.
+* ``SELENIUM_DOCKER_DEBUG`` - True if the debug version of the selenium Docker
+  container should be used (in order to allow VNC connections).  Only relevant
+  when the ``--docker`` parameter is used.  Default value is ``False``.
+* ``SELENIUM_DOCKER_PORT`` - The port of localhost (or the Docker Machine, on
+  Mac and Windows) at which to expose the Selenium server running in a Docker
+  container.  Only relevant when the ``--docker`` parameter is used.  Default
+  value is ``4444``.
+* ``SELENIUM_DOCKER_TAG`` - The tag to use in identifying which version of the
+  Selenium Docker container to start.  Only relevant when the ``--docker``
+  parameter is used.  Default value is ``2.53.0``.
 * ``SELENIUM_PAGE_LOAD_TIMEOUT`` - The number of seconds to wait for a response
   to a GET request before considering it to have failed.  Default value is 10
   seconds.  (This is particularly important when using Sauce Connect, as it
@@ -175,6 +185,14 @@ address (rarely ideal) or try to deduce it via code like the following::
 
     import socket
     DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(socket.gethostbyname(socket.gethostname()))
+
+As a convenience, you can use the ``--docker`` parameter to automatically start
+a standalone Selenium server in a Docker container for chrome or firefox tests.
+For this to work, the terminal must already be configured for ``docker``
+commands to work.  The container will be stopped automatically at the end of
+the test run.  By default it uses the ``latest`` image from
+https://hub.docker.com/r/selenium/ and is exposed on port 4444, but this can
+be customized via the Django settings described above.
 
 Alternatively, tests can be run at Sauce Labs; see below for details.
 

--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,7 @@ As a convenience, you can use the ``--docker`` parameter to automatically start
 a standalone Selenium server in a Docker container for chrome or firefox tests.
 For this to work, the terminal must already be configured for ``docker``
 commands to work.  The container will be stopped automatically at the end of
-the test run.  By default it uses the ``latest`` image from
+the test run.  By default it uses the ``2.53.0`` image from
 https://hub.docker.com/r/selenium/ and is exposed on port 4444, but this can
 be customized via the Django settings described above.
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,11 +5,17 @@ sbo-selenium Changelog
 ------------------
 * Added the ``--command-executor`` option for specifying which Selenium server
   to use, if not localhost
+* Added the ``--docker`` option to automatically start and stop a Docker
+  container for a standalone Selenium server to be used, and added a few
+  related Django settings
 * Fixed handling of custom parameters to work with recent versions of
   django-nose
 * Changed monitoring of the Selenium server auto-launching to watch stderr
   instead of stdout for the startup complete message, as recent versions of
   Selenium seem to have moved the startup output there
+* Fixed a bug where the code for timing out attempts to start certain services
+  (like a standalone Selenium server or Sauce Connect) was taking far longer
+  than intended to time out
 
 0.6.0 (2016-03-29)
 ------------------

--- a/sbo_selenium/conf.py
+++ b/sbo_selenium/conf.py
@@ -20,6 +20,21 @@ class LazySettings(object):
         return getattr(django_settings, 'SELENIUM_DEFAULT_TESTS', [])
 
     @property
+    def SELENIUM_DOCKER_DEBUG(self):
+        """True if the debug version of the selenium docker container should be used (for VNC connections)"""
+        return getattr(django_settings, 'SELENIUM_DOCKER_DEBUG', False)
+
+    @property
+    def SELENIUM_DOCKER_PORT(self):
+        """Port to use for a Selenium standalone server docker container"""
+        return getattr(django_settings, 'SELENIUM_DOCKER_PORT', 4444)
+
+    @property
+    def SELENIUM_DOCKER_TAG(self):
+        """Which tag of the Selenium standalone server docker container to use"""
+        return getattr(django_settings, 'SELENIUM_DOCKER_TAG', '2.53.0')
+
+    @property
     def SELENIUM_POLL_FREQUENCY(self):
         """Default operation retry frequency"""
         return getattr(django_settings, 'SELENIUM_POLL_FREQUENCY', 0.5)

--- a/sbo_selenium/utils.py
+++ b/sbo_selenium/utils.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 from io import StringIO
+from subprocess import CalledProcessError, check_call, check_output, Popen,\
+                       PIPE
 import uuid
 import threading
 import time
@@ -179,8 +181,10 @@ class OutputMonitor:
         """
         found = False
         stream = self.stream
-        start_time = time.clock()
+        start_time = time.time()
         while not found:
+            if time.time() - start_time > seconds:
+                break
             stream.data_available.wait(0.5)
             stream.data_unoccupied.clear()
             while stream.data:
@@ -191,6 +195,74 @@ class OutputMonitor:
                 self.lines.append(value)
                 stream.data_available.clear()
                 stream.data_unoccupied.set()
-                if time.clock() - start_time > seconds:
+                if time.time() - start_time > seconds:
                     break
         return found
+
+
+class DockerSelenium:
+    """
+    Configuration for a Docker-hosted standalone Selenium server which can be
+    started and stopped as desired.  Assumes that the terminal is already
+    configured for command-line docker usage, and uses the images provided by
+    https://github.com/SeleniumHQ/docker-selenium .
+    """
+
+    def __init__(self, browser='chrome', port=4444, tag='2.53.0', debug=False):
+        self.container_id = None
+        self.ip_address = None
+        self.port = port
+        shared_memory = '-v /dev/shm:/dev/shm' if browser == 'chrome' else ''
+        debug_suffix = '-debug' if debug else ''
+        image_name = 'selenium/standalone-{}{}:{}'.format(browser,
+                                                          debug_suffix, tag)
+        self.command = 'docker run -d -p {}:4444 {} {}'.format(port,
+                                                               shared_memory,
+                                                               image_name)
+
+    def command_executor(self):
+        """Get the appropriate command executor URL for the Selenium server
+        running in the Docker container."""
+        ip_address = self.ip_address if self.ip_address else '127.0.0.1'
+        return 'http://{}:{}/wd/hub'.format(ip_address, self.port)
+
+    def start(self):
+        """Start the Docker container"""
+        if self.container_id is not None:
+            msg = 'The Docker container is already running with ID {}'
+            raise Exception(msg.format(self.container_id))
+
+        process = Popen(['docker ps | grep ":{}"'.format(self.port)],
+                        shell=True, stdout=PIPE)
+        (grep_output, _grep_error) = process.communicate()
+        lines = grep_output.split('\n')
+        for line in lines:
+            if ':{}'.format(self.port) in line:
+                other_id = line.split()[0]
+                msg = 'Port {} is already being used by container {}'
+                raise Exception(msg.format(self.port, other_id))
+
+        self.container_id = check_output(self.command, shell=True).strip()
+        try:
+            self.ip_address = check_output(['docker-machine', 'ip']).strip()
+        except CalledProcessError:
+            self.ip_address = '127.0.0.1'
+
+        output = OutputMonitor()
+        logs_process = Popen(['docker', 'logs', '-f', self.container_id],
+                             stdout=output.stream.input,
+                             stderr=open(os.devnull, 'w'))
+        ready_log_line = 'Selenium Server is up and running'
+        if not output.wait_for(ready_log_line, 10):
+            logs_process.kill()
+            msg = 'Timeout starting the Selenium server Docker container:\n'
+            msg += '\n'.join(output.lines)
+            raise Exception(msg)
+        logs_process.kill()
+
+    def stop(self):
+        """Stop the Docker container"""
+        if self.container_id is None:
+            raise Exception('No Docker Selenium container was running')
+        check_call(['docker', 'stop', self.container_id])
+        self.container_id = None


### PR DESCRIPTION
Option to automatically start a Docker container containing a standalone Selenium server running either chrome or firefox.  Depends on the terminal having already been configured for docker commands to run correctly (with a Docker Machine already started, if necessary).  Currently uses the same container for the entire test suite, although the start/stop code is separated out so support could be added later for restarting it after each test class or even each test case.