### PR TITLE
Fix support for specifying tests on the command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,22 @@ usual for the containing project; for SBO packages this is typically::
 
     pip install -r requirements/tests.txt
 
-To run tests using a particular browser, it needs to already be installed.  To
-drive Chrome via Selenium, you'll need to install both Chrome itself and then
-chromedriver:
- 
-1. Download the correct ChromeDriver from http://chromedriver.storage.googleapis.com/index.html
-2. Put the binary, ``chromedriver``, somewhere on your path
-   (ex: ``/usr/local/bin/chromedriver``)
+Make sure the post-merge runs to install all of the prerequisites::
+
+    ./git-hooks/post-merge
+
+Browser engines
++++++++++++++++
+
+If you are running tests using docker, you don't need to worry about this part.
+
+If you are not using docker, to run tests using a particular browser, the
+browser driver needs to be present. To drive Chrome via Selenium, you'll need
+to install both Chrome itself and then chromedriver:
+
+1. Download the correct ChromeDriver from
+http://chromedriver.storage.googleapis.com/index.html 2. Put the binary,
+``chromedriver``, somewhere on your path (ex: ``/usr/local/bin/chromedriver``)
 
 On Mac OS X, if you have Homebrew installed you can instead run
 ``brew install chromedriver``.
@@ -134,9 +143,16 @@ related pages.
 Running Tests
 -------------
 
+Running Tests Locally
++++++++++++++++++++++
+
 Tests can be run via the "selenium" management command::
 
     ./manage.py selenium --settings=myapp.selenium_settings
+
+To run the default set of sbo-selenium tests::
+
+    ./manage.py selenium
 
 Or to specify which test(s) to run rather than using the defaults specified in
 the settings file::
@@ -158,7 +174,7 @@ All the usual methods that the test runner uses to identify tests should work::
     python.module
     python.module:TestClass
     python.module:TestClass.test_method
-    
+
 (Note that a specifying a package, like myapp.tests.selenium when the actual
 tests are defined in modules within that package, does NOT work.)
 
@@ -186,24 +202,28 @@ address (rarely ideal) or try to deduce it via code like the following::
     import socket
     DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(socket.gethostbyname(socket.gethostname()))
 
-As a convenience, you can use the ``--docker`` parameter to automatically start
-a standalone Selenium server in a Docker container for chrome or firefox tests.
-For this to work, the terminal must already be configured for ``docker``
-commands to work.  The container will be stopped automatically at the end of
-the test run.  By default it uses the ``2.53.0`` image from
-https://hub.docker.com/r/selenium/ and is exposed on port 4444, but this can
-be customized via the Django settings described above.
-
-Alternatively, tests can be run at Sauce Labs; see below for details.
-
 You can also specify the number of times to run the tests (for example, if you
 have a test that is failing intermittently for some reason and want to run it
 a few times to increase the odds of encountering the error)::
 
     ./manage.py selenium -n 5
 
-Sauce Labs
-----------
+Running Tests in a Docker Container
++++++++++++++++++++++++++++++++++++
+
+As a convenience, you can use the ``--docker`` parameter to automatically start
+a standalone Selenium server in a Docker container for chrome or firefox tests.
+For this to work, the terminal must already be configured for ``docker``
+commands to work.  The container will be stopped automatically at the end of
+the test run.  By default it uses the ``2.53.0`` image from
+https://hub.docker.com/r/selenium/ and is exposed on port 4444, but this can
+be customized via the Django settings described above.::
+
+    ./manage.py selenium --settings=myapp.selenium_settings --docker
+    ./manage.py selenium --docker
+
+Running Tests at Sauce Labs
++++++++++++++++++++++++++++
 
 Instead of running tests in a local browser, they can be run on one in a
 virtual machine hosted at  `Sauce Labs <https://saucelabs.com/home>`_.  Support

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ browser driver needs to be present. To drive Chrome via Selenium, you'll need
 to install both Chrome itself and then chromedriver:
 
 1. Download the correct ChromeDriver from
-http://chromedriver.storage.googleapis.com/index.html 2. Put the binary,
-``chromedriver``, somewhere on your path (ex: ``/usr/local/bin/chromedriver``)
+http://chromedriver.storage.googleapis.com/index.html 
+2. Put the binary, ``chromedriver``, somewhere on your path (ex: ``/usr/local/bin/chromedriver``)
 
 On Mac OS X, if you have Homebrew installed you can instead run
 ``brew install chromedriver``.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,7 +1,13 @@
 sbo-selenium Changelog
 ======================
 
-0.7.0 (2016-04-20)
+0.7.1 (2016-04-22)
+------------------
+* Fixed support for specifying which tests to run on the command line.  This
+  seems to have been broken for Django versions which use argparse to parse
+  management command options since support was added for them.
+
+0.7.0 (2016-04-21)
 ------------------
 * Added the ``--command-executor`` option for specifying which Selenium server
   to use, if not localhost

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -39,7 +39,7 @@ if virtual_env:
 
     os.system('requirements/clean_up_requirements.py')
     # Set Django version to use outside of tox
-    os.system("pip install Django==1.9.4")
+    os.system("pip install Django==1.9.5")
     os.system("pip install --requirement requirements/base.txt")
     os.system("pip install --requirement requirements/tox.txt")
     os.system("pip install --requirement requirements/tests.txt")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core dependencies common to all Python interpreters
 
 # Python packaging utilities
-setuptools==20.4
+setuptools==20.9.0
 
 # Package manager
 pip==8.1.1
@@ -15,4 +15,4 @@ pip==8.1.1
 requests==2.9.1
 
 # Python's Selenium driver (for browser automation)
-selenium==2.53.1
+selenium==2.53.2

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -15,8 +15,11 @@ bleach==1.4.2
 docutils==0.12
 Pygments==2.1.3
 
+# sbo-sphinx -> recommonmark
+CommonMark==0.5.5
+
 # sbo-sphinx -> Sphinx -> Babel
-pytz==2016.3
+pytz==2016.4
 
 # sbo-sphinx -> Sphinx -> Jinja2
 MarkupSafe==0.23
@@ -25,12 +28,13 @@ MarkupSafe==0.23
 PyStemmer==1.3.0
 
 # sbo-sphinx-> Sphinx
-Babel==2.2.0
+Babel==2.3.4
 Jinja2==2.8
 snowballstemmer==1.2.1
 
 # sbo-sphinx
-Sphinx==1.4
+recommonmark==0.4.0
+Sphinx==1.4.1
 
 # Sphinx themes (circular dependencies of Sphinx)
 alabaster==0.7.7

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,8 +2,11 @@
 
 # Indirect dependencies first, exact versions for consistency
 
+# ipdb -> ipython -> pexpect
+ptyprocess==0.5.1; sys_platform != 'win32'
+
 # ipdb -> ipython -> pickleshare
-path.py==8.1.2
+path.py==8.2.1
 
 # ipdb -> ipython -> traitlets
 decorator==4.0.9
@@ -13,12 +16,12 @@ ipython-genutils==0.1.0
 appnope==0.1.0; sys_platform == 'darwin'
 gnureadline==6.3.3; sys_platform == 'darwin'
 pexpect==4.0.1; sys_platform != 'win32'
-pickleshare==0.6
+pickleshare==0.7.2
 simplegeneric==0.8.1
 traitlets==4.2.1
 
 # ipdb
-ipython==4.1.2
+ipython==4.2.0
 
 # django-nose
 nose==1.3.7
@@ -29,4 +32,4 @@ nose==1.3.7
 django-nose==1.4.3
 
 # A better debugger
-ipdb==0.9.0
+ipdb==0.9.3

--- a/sbo_selenium/management/commands/selenium.py
+++ b/sbo_selenium/management/commands/selenium.py
@@ -35,7 +35,6 @@ class Command(BaseCommand):
     """
     Django management command for running Selenium tests.
     """
-    args = '<package or test>'
     help = 'Run Selenium tests for this application'
     requires_model_validation = True
     # Command line arguments for Django 1.7 and below

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()
 
 
-version = '0.7.0'  # Remember to update docs/CHANGELOG.rst when this changes
+version = '0.7.1'  # Remember to update docs/CHANGELOG.rst when this changes
 
 setup(
     name="sbo-selenium",

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist = py{27,34}-django{16,17,18,19,master},py35-django{18,19,master}
 deps =
     django16: Django==1.6.11
     django17: Django==1.7.11
-    django18: Django==1.8.11
-    django19: Django==1.9.4
+    django18: Django==1.8.12
+    django19: Django==1.9.5
     master: git+git://github.com/django/django.git
     -r{toxinidir}/requirements/tests.txt
 setenv =


### PR DESCRIPTION
* Removed a stray configuration option which has been preventing specification of the tests to run on the command line when using an argparse-based test command.
* Made some updates to the README for better clarity
* Updated the versions of dependencies used for testing