### PR TITLE
Document and demonstrate how to use docker-machine with tox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,11 +196,15 @@ etc.), you can use the ``--command-executor`` parameter::
 
 Note that if you are using a command executor in a Docker container, a remote
 host, etc., you should not rely on ``localhost`` or ``127.0.0.1`` in
-``DJANGO_LIVE_TEST_SERVER_ADDRESS``.  Instead, either specify the real IP
-address (rarely ideal) or try to deduce it via code like the following::
+``DJANGO_LIVE_TEST_SERVER_ADDRESS`` and must add the IP address which will be
+used to access the server to ``ALLOWED_HOSTS``.  You can either specify the
+real IP address (rarely ideal) or try to deduce it via code like the
+following::
 
     import socket
-    DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(socket.gethostbyname(socket.gethostname()))
+    IP_ADDRESS = socket.gethostbyname(socket.gethostname())
+    ALLOWED_HOSTS = ['localhost', IP_ADDRESS]
+    DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(IP_ADDRESS)
 
 You can also specify the number of times to run the tests (for example, if you
 have a test that is failing intermittently for some reason and want to run it
@@ -221,6 +225,15 @@ be customized via the Django settings described above.::
 
     ./manage.py selenium --settings=myapp.selenium_settings --docker
     ./manage.py selenium --docker
+
+Note that if you're running Docker containers in a virtual machine via
+``docker-machine`` or such and using ``tox``, you'll need to allow some
+environment variables to be passed through to the tox environment by adding
+the following to the appropriate environment in ``tox.ini``::
+
+    passenv =
+        DOCKER_*
+        HOME
 
 Running Tests at Sauce Labs
 +++++++++++++++++++++++++++

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,11 @@
 sbo-selenium Changelog
 ======================
 
+0.7.2 (2016-05-05)
+------------------
+* Clarify and demonstrate how to successfully run tests via a Docker-based
+  Selenium server in a virtual machine while using tox.
+
 0.7.1 (2016-04-22)
 ------------------
 * Fixed support for specifying which tests to run on the command line.  This

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -39,7 +39,7 @@ if virtual_env:
 
     os.system('requirements/clean_up_requirements.py')
     # Set Django version to use outside of tox
-    os.system("pip install Django==1.9.5")
+    os.system("pip install Django==1.9.6")
     os.system("pip install --requirement requirements/base.txt")
     os.system("pip install --requirement requirements/tox.txt")
     os.system("pip install --requirement requirements/tests.txt")

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -5,7 +5,7 @@
 # flake8
 mccabe==0.4.0
 pep8==1.7.0
-pyflakes==1.1.0
+pyflakes==1.2.0
 
 # And now the direct dependencies
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core dependencies common to all Python interpreters
 
 # Python packaging utilities
-setuptools==20.9.0
+setuptools==21.0.0
 
 # Package manager
 pip==8.1.1
@@ -12,7 +12,7 @@ pip==8.1.1
 # test multiple versions of it
 
 # HTTP library for calls to Sauce REST API for reporting test results
-requests==2.9.1
+requests==2.10.0
 
 # Python's Selenium driver (for browser automation)
 selenium==2.53.2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -32,4 +32,4 @@ nose==1.3.7
 django-nose==1.4.3
 
 # A better debugger
-ipdb==0.9.3
+ipdb==0.10.0

--- a/sbo_selenium/utils.py
+++ b/sbo_selenium/utils.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from io import StringIO
 from subprocess import CalledProcessError, check_call, check_output, Popen,\
-                       PIPE
+    PIPE
 import uuid
 import threading
 import time

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()
 
 
-version = '0.7.1'  # Remember to update docs/CHANGELOG.rst when this changes
+version = '0.7.2'  # Remember to update docs/CHANGELOG.rst when this changes
 
 setup(
     name="sbo-selenium",

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,8 +3,8 @@ import socket
 
 DEBUG = False
 JS_DEBUG = False
-ALLOWED_HOSTS = ['localhost']
 IP_ADDRESS = socket.gethostbyname(socket.gethostname())
+ALLOWED_HOSTS = ['localhost', IP_ADDRESS]
 DJANGO_LIVE_TEST_SERVER_ADDRESS = '{}:9090'.format(IP_ADDRESS)
 SELENIUM_SAUCE_VERSION = '2.41.0'
 SELENIUM_TIMEOUT = 10

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,13 @@ envlist = py{27,34}-django{16,17,18,19,master},py35-django{18,19,master}
 deps =
     django16: Django==1.6.11
     django17: Django==1.7.11
-    django18: Django==1.8.12
-    django19: Django==1.9.5
+    django18: Django==1.8.13
+    django19: Django==1.9.6
     master: git+git://github.com/django/django.git
     -r{toxinidir}/requirements/tests.txt
+passenv =
+    DOCKER_*
+    HOME
 setenv =
     DJANGO_SETTINGS_MODULE=test_settings
 commands =


### PR DESCRIPTION
* Updated the README, ``test_settings``, and ``tox.ini`` to correctly run Docker-based Selenium tests via tox when using a VM to run the container
* Updated testing dependencies